### PR TITLE
Setup page

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -3,4 +3,20 @@ layout: page
 title: Setup
 permalink: /setup/
 ---
-FIXME
+To follow the Common Workflow Language user guide, you will need an up-to-date
+Linux or Mac OS X system, with the following software installed:
+
+- A text editor with YAML support
+- A CWL implementation to run the described tools and workflows. When first
+getting started with CWL, we recommend the reference implementation,
+[`cwltool`][ref-imp]. You can find a full list on
+[the project homepage][commonwl].
+- Most of the software tools used in the user guide are standard UNIX commands
+(`cat`, `echo`, `env`, `tar`, `touch`, `wc`), but to run all examples you will
+also need:
+  - node.js
+  - Java compiler
+  - Docker (optional)
+
+[ref-imp]: https://github.com/common-workflow-language/cwltool
+[commonwl]: http://www.commonwl.org/


### PR DESCRIPTION
Fixes #9 

Added setup page with more detailed installation info than in the 'prerequisites' section of the user guide intro.