### PR TITLE
WIP `enum` example

### DIFF
--- a/_includes/cwl/enum.cwl
+++ b/_includes/cwl/enum.cwl
@@ -1,0 +1,29 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+baseCommand: grep
+
+inputs:
+  directory_handling:
+    inputBinding:
+      position: 0
+      prefix: --directories=
+      separate: false
+    type:
+      type: enum
+      symbols: [read, skip, recurse]
+    default: read
+  search_pattern:
+    inputBinding:
+      position: 1
+    type: string
+  search_target:
+    inputBinding:
+      position: 2
+    type: Directory
+
+outputs:
+  output:
+    type: stdout

--- a/_includes/cwl/grep-job.yml
+++ b/_includes/cwl/grep-job.yml
@@ -1,0 +1,5 @@
+directory_handling: recurse
+search_pattern: abc
+search_target:
+    class: Directory
+    path: .


### PR DESCRIPTION
I've created an example of using `enum` syntax in a CWL wrapper to `grep` with the `--directories={read|skip|recurse}` option. Not sure if this is appropriate? @mr-c will probably be suspicious of my use of `type: Directory`...

I wanted to use a GNU tool that would be installed as standard, at least on linux/mac devices.

Any thoughts on a better example/how to improve this one?