### PR TITLE
Consistent formatting and additional array detail

### DIFF
--- a/_episodes/02-1st-example.md
+++ b/_episodes/02-1st-example.md
@@ -22,7 +22,7 @@ The simplest "hello world" program.  This accepts one input parameter, writes a 
 ~~~
 {: .source}
 
-Use a YAML object in a separate file to describe the input of a run:
+Use a YAML or JSON object in a separate file to describe the input of a run:
 
 *echo-job.yml*
 ~~~

--- a/_episodes/09-array-inputs.md
+++ b/_episodes/09-array-inputs.md
@@ -54,6 +54,7 @@ In addition, the `itemSeperator` field, if provided, specifies that array
 values should be concatenated into a single argument separated by the item
 separator string.
 
-Note that the arrays of inputs are specified inside square brackets `[]` in `array-inputs-job.yml`. Arrays can also be expressed over multiple lines, with
-each entry marked by a leading `-`, as demonstrated in the next lesson. 
+Note that the arrays of inputs are specified inside square brackets `[]` in `array-inputs-job.yml`. Arrays can also be expressed over multiple lines, where
+array values that are not defined with an associated key is marked by a leading
+`-`, as demonstrated in the next lesson. 
 You can specify arrays of arrays, arrays of records, and other complex types.

--- a/_episodes/09-array-inputs.md
+++ b/_episodes/09-array-inputs.md
@@ -54,5 +54,6 @@ In addition, the `itemSeperator` field, if provided, specifies that array
 values should be concatenated into a single argument separated by the item
 separator string.
 
-You can specify arrays of arrays, arrays of records, and other complex
-types.
+Note that the arrays of inputs are specified inside square brackets `[]` in `array-inputs-job.yml`. Arrays can also be expressed over multiple lines, with
+each entry marked by a leading `-`, as demonstrated in the next lesson. 
+You can specify arrays of arrays, arrays of records, and other complex types.

--- a/_episodes/10-array-outputs.md
+++ b/_episodes/10-array-outputs.md
@@ -52,3 +52,7 @@ Final process status is success
 }
 ~~~
 {: .output}
+
+The array of expected outputs is specified in `array-outputs-job.yml` with each
+entry marked by a leading `-`. This format can also be used in CWL descriptions
+to mark entries in arrays, as demonstrated in several of the upcoming sections.

--- a/_episodes/13-expressions.md
+++ b/_episodes/13-expressions.md
@@ -43,7 +43,7 @@ job file:
 
 `empty.yml` contains a description of an empty JSON object. JSON objects
 descriptions are contained inside curly brackets `{}`, so an empty object is
-represented simply by a set of empyty brackets.
+represented simply by a set of empty brackets.
 
 We can then run `expression.cwl`:
 

--- a/_episodes/13-expressions.md
+++ b/_episodes/13-expressions.md
@@ -57,8 +57,8 @@ Final process status is success
 {: .output}
 
 Note that requirements must be provided as an array, with each entry (in this
-case, only `class: InlineJavascriptRequirement`) marked by a `-`, as are the
-additional command line arguments.
+case, only `class: InlineJavascriptRequirement`) marked by a `-`. The same
+syntax is used to describe the additional command line arguments.
 
 You can only use expressions in certain fields.  These are:
 

--- a/_episodes/13-expressions.md
+++ b/_episodes/13-expressions.md
@@ -56,6 +56,10 @@ Final process status is success
 ~~~
 {: .output}
 
+Note that requirements must be provided as an array, with each entry (in this
+case, only `class: InlineJavascriptRequirement`) marked by a `-`, as are the
+additional command line arguments.
+
 You can only use expressions in certain fields.  These are:
 
 - `filename`

--- a/_episodes/13-expressions.md
+++ b/_episodes/13-expressions.md
@@ -31,7 +31,8 @@ See the [list of recommended practices][rec-practices].__
 ~~~
 {: .source}
 
-As this tool does not require any `inputs` we can run it with an (almost) empty job file:
+As this tool does not require any `inputs` we can run it with an (almost) empty
+job file:
 
 *empty.yml*
 
@@ -39,6 +40,10 @@ As this tool does not require any `inputs` we can run it with an (almost) empty 
 {% include cwl/empty.yml %}
 ~~~
 {: .source}
+
+`empty.yml` contains a description of an empty JSON object. JSON objects
+descriptions are contained inside curly brackets `{}`, so an empty object is
+represented simply by a set of empyty brackets.
 
 We can then run `expression.cwl`:
 

--- a/_includes/cwl/record.cwl
+++ b/_includes/cwl/record.cwl
@@ -18,19 +18,19 @@ inputs:
             prefix: -B
   exclusive_parameters:
     type:
-      - type: record
-        name: itemC
-        fields:
-          itemC:
-            type: string
-            inputBinding:
-              prefix: -C
-      - type: record
-        name: itemD
-        fields:
-          itemD:
-            type: string
-            inputBinding:
-              prefix: -D
+      type: record
+      name: itemC
+      fields:
+        itemC:
+          type: string
+          inputBinding:
+            prefix: -C
+      type: record
+      name: itemD
+      fields:
+        itemD:
+          type: string
+          inputBinding:
+            prefix: -D
 outputs: []
 baseCommand: echo


### PR DESCRIPTION
Addresses https://github.com/common-workflow-language/common-workflow-language/issues/318

- Made array formatting in `record.cwl` consistent
- Added short explanation of YAML array formats, in input files and in CWL descriptions
- Added short explanation of empty JSON object in `empty.yml` (should this be `empty.json` really? How does one write an explicitly empty YAML file/object?)