### PR TITLE
Fix input file parameter name

### DIFF
--- a/_includes/cwl/sample.yml
+++ b/_includes/cwl/sample.yml
@@ -1,4 +1,4 @@
-bam_input:
+aligned_sequences:
     class: File
     format: http://edamontology.org/format_2572
     path: file-formats.bam


### PR DESCRIPTION
In user guide 16  `cwl/metadata_exmple.cwl` and in that cwl file specified input files following

https://github.com/common-workflow-language/user_guide/blob/68a9ecdbbb1759ff15264937e049984b33ed1041/_includes/cwl/metadata_example.cwl#L8

`aligned_sequences` is used.

