### PR TITLE
Fix record.cwl to make section 11 workable for record-job2.yml

### DIFF
--- a/_includes/cwl/record.cwl
+++ b/_includes/cwl/record.cwl
@@ -18,19 +18,19 @@ inputs:
             prefix: -B
   exclusive_parameters:
     type:
-      type: record
-      name: itemC
-      fields:
-        itemC:
-          type: string
-          inputBinding:
-            prefix: -C
-      type: record
-      name: itemD
-      fields:
-        itemD:
-          type: string
-          inputBinding:
-            prefix: -D
+      - type: record
+        name: itemC
+        fields:
+          itemC:
+            type: string
+            inputBinding:
+              prefix: -C
+      - type: record
+        name: itemD
+        fields:
+          itemD:
+            type: string
+            inputBinding:
+              prefix: -D
 outputs: []
 baseCommand: echo


### PR DESCRIPTION
Currently an example `record.cwl` with `record-job2.yml` in section 11 does not return the same result as shown in the section.

Expected:
Section 11 shows that (`itemC` is chosen):
```console
$ cwl-runner record.cwl record-job2.yml
[job 140566927111376] /home/example$ echo -A one -B two -C three
-A one -B two -C three
Final process status is success
{}
```

Actual (`itemD` is chosen):
```console
$ cwl-runner record.cwl record-job2.yml
/Users/tom-tan/.pyenv/versions/3.6.2/bin/cwl-runner 1.0.20170908110401
Resolved 'record.cwl' to 'file:///Users/tom-tan/repos/user_guide/_includes/cwl/record.cwl'
[job record.cwl] /private/var/folders/gk/zyzswjbs6m59ywz69zhrtmlh0000gn/T/tmpgyqxniuj$ echo \
    -A \
    one \
    -B \
    two \
    -D \
    four
-A one -B two -D four
[job record.cwl] completed success
{}
Final process status is success
```

After merging this request:
```console
$ cwl-runner record.cwl record-job2.yml
/Users/tom-tan/.pyenv/versions/3.6.2/bin/cwl-runner 1.0.20170908110401
Resolved 'record.cwl' to 'file:///Users/tom-tan/repos/user_guide/_includes/cwl/record.cwl'
record-job2.yml:6:3: invalid field `itemD`, expected one of: 'itemC'
[job record.cwl] /private/var/folders/gk/zyzswjbs6m59ywz69zhrtmlh0000gn/T/tmpef_u3_sk$ echo \
    -A \
    one \
    -B \
    two \
    -C \
    three
-A one -B two -C three
[job record.cwl] completed success
{}
Final process status is success
```
It shows the same command shown in the section. Also, latest `cwl-runner` prints a good warning for exclusive parameters.



