### PR TITLE
URL for the user guide changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![DOI](https://zenodo.org/badge/89621457.svg)](https://zenodo.org/badge/latestdoi/89621457)
 
-User guide for CWL v1.0.1
+[User guide for CWL v1.0.1](http://www.commonwl.org/user_guide/)
 
 Original source:
-http://www.commonwl.org/user_guide/
-which is built from
 https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/UserGuide.yml

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 User guide for CWL v1.0.1
 
 Original source:
-http://www.commonwl.org/v1.0/UserGuide.html
+http://www.commonwl.org/user_guide/
 which is built from
 https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/UserGuide.yml


### PR DESCRIPTION
http://www.commonwl.org/v1.0/UserGuide.html is simply a landing page with a link to http://www.commonwl.org/user_guide/.

This single line changes removes a click for new users.

---

Unless this is an intentional redirection, I would recommend direct linking the user guide, simply for ease of use for new users (like myself).
