### PR TITLE
Add conformance test for section 4 using cwltest

### DIFF
--- a/_includes/cwl/conformance-test.yml
+++ b/_includes/cwl/conformance-test.yml
@@ -1,0 +1,10 @@
+- doc: Test for section 4
+  job: 04-output/tar-job.yml
+  tool: 04-output/tar.cwl
+  output:
+    example_out:
+      class: File
+      checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
+      basename: hello.txt
+      location: Any
+      size: 0


### PR DESCRIPTION
This request partially solves #37.
After merging this request, we can test the example in section 4 by using the following command in `_includes/cwl`:

```console
$ cwltest --test=conformance-test.yml
```

Currently it is blocked by #51.