### PR TITLE
Add .travis.yml to test the examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - 2.7
+  - 3.6
+
+before_script:
+  - git clone https://github.com/common-workflow-language/cwltool.git cwltool && pip install ./cwltool
+  - git clone https://github.com/common-workflow-language/cwltest.git cwltest && pip install ./cwltest
+
+script:
+  - make RUNNER=cwltool unittest-examples

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,12 @@ lesson-figures :
 unittest :
 	python bin/test_lesson_check.py
 
+RUNNER=cwl-runner
+
+## unittest-examples: run unit tests for the examples
+unittest-examples :
+	cd _includes/cwl; cwltest --test=conformance-test.yml --tool=${RUNNER}
+
 ## lesson-files     : show expected names of generated files for debugging.
 lesson-files :
 	@echo 'RMD_SRC:' ${RMD_SRC}


### PR DESCRIPTION
This request partially solves #37.

It adds:
- `unittest-examples` target to `Makefile` that simply run `cwltest`. We can customize CWL runner via `RUNNER` variable.
- `.travis.yml` for Travis CI. It executes `make unittest-examples RUNNER=cwltool` with python 2.7 and python 3.6.
