### PR TITLE
Enable CI for gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ python:
   - 2.7
   - 3.6
 
+branches:
+  only:
+    - gh-pages
+    - /.*/
+
 before_script:
   - git clone https://github.com/common-workflow-language/cwltool.git cwltool && pip install ./cwltool
   - git clone https://github.com/common-workflow-language/cwltest.git cwltest && pip install ./cwltest


### PR DESCRIPTION
By default, Travis CI disables the build for gh-pages branch.
This request fixes it.

See also: https://docs.travis-ci.com/user/customizing-the-build/#Building-Specific-Branches
