### PR TITLE
Add tests for the examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+sudo: required
+services:
+  - docker
+
 language: python
 python:
   - 2.7

--- a/_includes/cwl/17-metadata/sample.yml
+++ b/_includes/cwl/17-metadata/sample.yml
@@ -1,0 +1,7 @@
+aligned_sequences:
+    class: File
+    format: http://edamontology.org/format_2572
+    path: file-formats.bam
+bamstats_report:
+    class: File
+    path: /tmp/bamstats_report.zip

--- a/_includes/cwl/conformance-test.yml
+++ b/_includes/cwl/conformance-test.yml
@@ -1,3 +1,7 @@
+# Section 2 depends on side-effects
+# Section 3 depends on side-effects
+
+# Section 4
 - doc: Test for section 4
   job: 04-output/tar-job.yml
   tool: 04-output/tar.cwl
@@ -8,3 +12,158 @@
       basename: hello.txt
       location: Any
       size: 0
+
+# Section 5
+- doc: Test for section 5
+  job: 05-stdout/echo-job.yml
+  tool: 05-stdout/stdout.cwl
+  output:
+    output:
+      class: File
+      checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
+      basename: output.txt
+      location: Any
+      size: 13
+
+# Section 6
+- doc: Test for section 6
+  job: 06-params/tar-param-job.yml
+  tool: 06-params/tar-param.cwl
+  output:
+    example_out:
+      class: File
+      checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
+      basename: goodbye.txt
+      location: Any
+      size: 0
+
+# Section 7 depends on side-effects
+
+# Section 8
+# Note: Skip checking size and checksum of the resulted file because it depends on the external compiler.
+- doc: Test for section 8
+  job: 08-arguments/arguments-job.yml
+  tool: 08-arguments/arguments.cwl
+  output:
+    classfile:
+      class: File
+      basename: Hello.class
+      location: Any
+
+# Section 9 depends on side-effects
+
+# Section 10
+# Note: fragile! The order of `foo.txt` and `baz.txt` cannot be determined.
+- doc: Test for section 10
+  job: 10-array-outputs/array-outputs-job.yml
+  tool: 10-array-outputs/array-outputs.cwl
+  output:
+    output:
+      - class: File
+        basename: baz.txt
+        checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
+        location: Any
+        size: 0
+      - class: File
+        basename: foo.txt
+        checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
+        location: Any
+        size: 0
+
+# Section 11 depends on side-effects
+# Note: One of the tests in this section is expected to be failed
+# Rest of the examples depend on side-effects
+
+# Section 12 depends on side-effects
+# Section 13 depends on side-effects
+# Section 14 depends on side-effects
+
+# Section 15
+# Note: Skip checking size and checksum of the resulted file because it depends on the external compiler.
+- doc: Test for section 15
+  job: 15-staging/arguments-job.yml
+  tool: 15-staging/linkfile.cwl
+  output:
+    classfile:
+      class: File
+      basename: Hello.class
+      location: Any
+
+# Section 16
+# Note: The checksum is always changed for every executions
+- doc: Test for section 16
+  job: 16-file-formats/sample.yml
+  tool: 16-file-formats/metadata_example.cwl
+  output:
+    report:
+      class: File
+      basename: output.txt
+      location: Any
+      size: 132
+
+# Section 17
+# Note: The checksum is always changed for every executions
+- doc: Test for section 17 (1st example)
+  job: 17-metadata/sample.yml
+  tool: 17-metadata/metadata_example2.cwl
+  output:
+    report:
+      class: File
+      basename: output.txt
+      location: Any
+      size: 132
+
+- doc: Test for section 17 (extended example)
+  job: 17-metadata/sample.yml
+  tool: 17-metadata/metadata_example3.cwl
+  output:
+    report:
+      class: File
+      basename: output.txt
+      location: Any
+      size: 132
+
+# Section 19
+# See: Issue #48
+# - doc: Test for section 19
+#   job: 19-custom-types/custom-types.yml
+#   tool: 19-custom-types/costom-types.cwl
+#   output:
+#     i5Annotations:
+#       class: File
+#       basename: test_proteins.i5_annotations
+#       location: Any
+#       size: Any # To be fixed
+
+# Section 20
+# See: Issue #48
+# - doc: Test for section 20
+#   job: 20-software-requirements/custom-types.yml
+#   tool: 20-software-requirements/costom-types.cwl
+#   output:
+#     i5Annotations:
+#       class: File
+#       basename: test_proteins.i5_annotations
+#       location: Any
+#       size: Any # To be fixed
+
+# Section 21
+# Note: Skip checking size and checksum of the resulted file because it depends on the external compiler.
+- doc: Test for section 21
+  job: 21-1st-workflow/1st-workflow-job.yml
+  tool: 21-1st-workflow/1st-workflow.cwl
+  output:
+    classout:
+      class: File
+      basename: Hello.class
+      location: Any
+
+# Section 22
+# Note: Skip checking size and checksum of the resulted file because it depends on the external compiler.
+- doc: Test for section 22
+  tool: 22-nested-workflows/nestedworkflows.cwl
+  output:
+    classout:
+      class: File
+      basename: Hello.class
+      location: Any

--- a/_includes/cwl/conformance-test.yml
+++ b/_includes/cwl/conformance-test.yml
@@ -51,15 +51,16 @@
 # Section 7 depends on side-effects
 
 # Section 8
-# Note: Skip checking size and checksum of the resulted file because it depends on the external compiler.
 - doc: Test for section 8
   job: 08-arguments/arguments-job.yml
   tool: 08-arguments/arguments.cwl
   output:
     classfile:
       class: File
+      checksum: sha1$fdb876b40ad9ebc7fee873212e02d5940588642e
       basename: Hello.class
       location: Any
+      size: 184
 
 # Section 9 depends on side-effects
 
@@ -92,15 +93,16 @@
 # Section 14 depends on side-effects
 
 # Section 15
-# Note: Skip checking size and checksum of the resulted file because it depends on the external compiler.
 - doc: Test for section 15
   job: 15-staging/arguments-job.yml
   tool: 15-staging/linkfile.cwl
   output:
     classfile:
       class: File
+      checksum: sha1$fdb876b40ad9ebc7fee873212e02d5940588642e
       basename: Hello.class
       location: Any
+      size: 184
 
 # Section 16
 # Note: The checksum and size is always changed for every executions
@@ -158,22 +160,24 @@
 #       size: Any # To be fixed
 
 # Section 21
-# Note: Skip checking size and checksum of the resulted file because it depends on the external compiler.
 - doc: Test for section 21
   job: 21-1st-workflow/1st-workflow-job.yml
   tool: 21-1st-workflow/1st-workflow.cwl
   output:
     classout:
       class: File
+      checksum: sha1$39e3219327347c05aa3e82236f83aa6d77fe6bfd
       basename: Hello.class
       location: Any
+      size: 419
 
 # Section 22
-# Note: Skip checking size and checksum of the resulted file because it depends on the external compiler.
 - doc: Test for section 22
   tool: 22-nested-workflows/nestedworkflows.cwl
   output:
     classout:
       class: File
+      checksum: sha1$39e3219327347c05aa3e82236f83aa6d77fe6bfd
       basename: Hello.class
       location: Any
+      size: 419

--- a/_includes/cwl/conformance-test.yml
+++ b/_includes/cwl/conformance-test.yml
@@ -1,5 +1,16 @@
-# Section 2 depends on side-effects
-# Section 3 depends on side-effects
+# Section 2
+- doc: Test for section 2
+  job: 02-1st-example/echo-job.yml
+  tool: 02-1st-example/1st-tool.cwl
+  should_fail: false
+  output: {}
+
+# Section 3
+- doc: Test for section 3
+  job: 03-input/inp-job.yml
+  tool: 03-input/inp.cwl
+  should_fail: false
+  output: {}
 
 # Section 4
 - doc: Test for section 4
@@ -53,7 +64,6 @@
 # Section 9 depends on side-effects
 
 # Section 10
-# Note: fragile! The order of `foo.txt` and `baz.txt` cannot be determined.
 - doc: Test for section 10
   job: 10-array-outputs/array-outputs-job.yml
   tool: 10-array-outputs/array-outputs.cwl
@@ -71,8 +81,11 @@
         size: 0
 
 # Section 11 depends on side-effects
-# Note: One of the tests in this section is expected to be failed
-# Rest of the examples depend on side-effects
+# Rest two examples in Section 11 depend on side-effects
+- doc: Test for section 11 (1st example)
+  job: 11-records/record-job1.yml
+  tool: 11-records/record.cwl
+  should_fail: true
 
 # Section 12 depends on side-effects
 # Section 13 depends on side-effects

--- a/_includes/cwl/conformance-test.yml
+++ b/_includes/cwl/conformance-test.yml
@@ -99,7 +99,6 @@
       class: File
       basename: output.txt
       location: Any
-      size: Any
 
 # Section 17
 # Note: The checksum and size is always changed for every executions
@@ -111,7 +110,6 @@
       class: File
       basename: output.txt
       location: Any
-      size: Any
 
 - doc: Test for section 17 (extended example)
   job: 17-metadata/sample.yml
@@ -121,7 +119,6 @@
       class: File
       basename: output.txt
       location: Any
-      size: 132
 
 # Section 19
 # See: Issue #48

--- a/_includes/cwl/conformance-test.yml
+++ b/_includes/cwl/conformance-test.yml
@@ -90,7 +90,7 @@
       location: Any
 
 # Section 16
-# Note: The checksum is always changed for every executions
+# Note: The checksum and size is always changed for every executions
 - doc: Test for section 16
   job: 16-file-formats/sample.yml
   tool: 16-file-formats/metadata_example.cwl
@@ -99,10 +99,10 @@
       class: File
       basename: output.txt
       location: Any
-      size: 132
+      size: Any
 
 # Section 17
-# Note: The checksum is always changed for every executions
+# Note: The checksum and size is always changed for every executions
 - doc: Test for section 17 (1st example)
   job: 17-metadata/sample.yml
   tool: 17-metadata/metadata_example2.cwl
@@ -111,7 +111,7 @@
       class: File
       basename: output.txt
       location: Any
-      size: 132
+      size: Any
 
 - doc: Test for section 17 (extended example)
   job: 17-metadata/sample.yml


### PR DESCRIPTION
This request partially solve #37 by adding tests for the examples.

I do not add tests for the following sections:
- Section ~~2, 3,~~ 7, 9, 11 (2nd and 3rd examples), 12, 13 and 14
  - They depend on side-effects. It should be fixed to use `outputs` instead of side-effects.
  - I added test cases for Section 2 and 3 to check the examples in these sections runnable.
- ~~Section 11 (1st example)~~
  - ~~We expect it should fails but `cwltest` cannot test such cases. We should fix `cwltest` for known failure testing.~~
  - I added a test case for Section 11 (1st example) because the blocker is solved by [cwltest#38](https://github.com/common-workflow-language/cwltest/pull/38).
- Section 19 and 20
  - This repository does not contain the command for them due to its size (See #48). IMO it is better to use smaller examples that can be included in the repository.

Here are some notes for tests.
- I added several files to make the example in section 17 runnable.
- ~~I skipped checking the checksum and size of the resulted files for section 8, 15, 21 and 22 because they depends on the external compiler and it makes the tests fragile if we check the checksum and size.~~
  - Now we checks checksums and sizes for these sections.
- (edited) I skipped checking the checksum and size for the examples for section 16 and 17 because the outputs contain randomly generated paths and resulted checksums and sizes can be varied.
- ~~In this request, the test for section 10 expects that the glob in `outputs` returns files in the deterministic order. I am not sure it is a defined behavior or a system-dependent behavior.~~
  - Depending on the order of globing is harmless because it is deterministic (See [cwltool#587](https://github.com/common-workflow-language/cwltool/pull/587)).
