### PR TITLE
Fix link and update tags to fit to example

### DIFF
--- a/_episodes/21-1st-workflow.md
+++ b/_episodes/21-1st-workflow.md
@@ -138,4 +138,4 @@ connecting the input parameter `src` to the output parameter of `untar` using
 `untar/example_out`.  The output of this step `classfile` is connected to the
 `outputs` section for the Workflow, described above.
 
-[params]: /06-params/
+[params]: 06-params/

--- a/_episodes/21-1st-workflow.md
+++ b/_episodes/21-1st-workflow.md
@@ -11,8 +11,7 @@ keypoints:
 - "Top level inputs and outputs of the workflow are described in the `inputs`
 and `outputs` fields respectively."
 - "The steps are specified under `steps`."
-- "Execution order is determined by the flow of inputs and outputs between
-steps."
+- "Execution order is determined by the connections between steps."
 ---
 This workflow extracts a java source file from a tar file and then
 compiles it.
@@ -116,12 +115,12 @@ The first step, `untar` runs `tar-param.cwl` (described previously in
 [Parameter references][params]).  This tool has two input parameters, `tarfile`
 and `extractfile` and one output parameter `example_out`.
 
-The `inputs` (or `in`) section of the workflow step connects these two input parameters to
+The ``in`` section of the workflow step connects these two input parameters to
 the inputs of the workflow, `inp` and `ex` using `source`.  This means that when
 the workflow step is executed, the values assigned to `inp` and `ex` will be
 used for the parameters `tarfile` and `extractfile` in order to run the tool.
 
-The `outputs` (or `out`) section of the workflow step lists the output parameters that are
+The `out` section of the workflow step lists the output parameters that are
 expected from the tool.
 
 ~~~

--- a/_episodes/21-1st-workflow.md
+++ b/_episodes/21-1st-workflow.md
@@ -100,7 +100,7 @@ steps:
     in:
       tarfile: inp
       extractfile: ex
-    outputs: [example_out]
+    out: [example_out]
 ~~~
 {: .source}
 
@@ -116,12 +116,12 @@ The first step, `untar` runs `tar-param.cwl` (described previously in
 [Parameter references][params]).  This tool has two input parameters, `tarfile`
 and `extractfile` and one output parameter `example_out`.
 
-The `inputs` section of the workflow step connects these two input parameters to
+The `inputs` (or `in`) section of the workflow step connects these two input parameters to
 the inputs of the workflow, `inp` and `ex` using `source`.  This means that when
 the workflow step is executed, the values assigned to `inp` and `ex` will be
 used for the parameters `tarfile` and `extractfile` in order to run the tool.
 
-The `outputs` section of the workflow step lists the output parameters that are
+The `outputs` (or `out`) section of the workflow step lists the output parameters that are
 expected from the tool.
 
 ~~~
@@ -129,7 +129,7 @@ expected from the tool.
     run: arguments.cwl
     in:
       src: untar/example_out
-    outputs: [classfile]
+    out: [classfile]
 ~~~
 {: .source}
 
@@ -138,4 +138,4 @@ connecting the input parameter `src` to the output parameter of `untar` using
 `untar/example_out`.  The output of this step `classfile` is connected to the
 `outputs` section for the Workflow, described above.
 
-[params]: _episodes/06-params/
+[params]: /06-params/


### PR DESCRIPTION
Hi,
I have noticed that the link to Parameter references page was broken (http://www.commonwl.org/user_guide/21-1st-workflow/_episodes/06-params/) in the workflow page.
I also replaced `inputs` and `outputs` by `in` and `out` to fit to the first example given at the beginning of the Writing Workflows user guide.