### PR TITLE
Replace output identifier for section 7 with `example_out`

### DIFF
--- a/_episodes/07-containers.md
+++ b/_episodes/07-containers.md
@@ -65,7 +65,7 @@ $ cwl-runner docker.cwl docker-job.yml
     /var/lib/cwl/job369354770_examples/hello.js > /tmp/tmpgugLND/output.txt
 [job docker.cwl] completed success
 {
-    "output": {
+    "example_out": {
         "location": "file:///home/me/cwl/user_guide/output.txt",
         "basename": "output.txt",
         "class": "File",

--- a/_includes/cwl/07-containers/docker.cwl
+++ b/_includes/cwl/07-containers/docker.cwl
@@ -12,6 +12,6 @@ inputs:
     inputBinding:
       position: 1
 outputs:
-  output:
+  example_out:
     type: stdout
 stdout: output.txt

--- a/_includes/cwl/conformance-test.yml
+++ b/_includes/cwl/conformance-test.yml
@@ -53,7 +53,7 @@
   job: 07-containers/docker-job.yml
   tool: 07-containers/docker.cwl
   output:
-    output:
+    example_out:
       class: File
       checksum: sha1$648a6a6ffffdaa0badb23b8baf90b6168dd16b3a
       basename: output.txt


### PR DESCRIPTION
It just replaces the output identifier `output` with `example_out` because it is too generic name and may introduce confusions to users.
