### PR TITLE
Replace output identifier `output` with `example_out`

### DIFF
--- a/_episodes/05-stdout.md
+++ b/_episodes/05-stdout.md
@@ -37,7 +37,7 @@ $ cwl-runner stdout.cwl echo-job.yml
     'Hello world!' > /tmp/tmpE0gTz7/output.txt
 [job stdout.cwl] completed success
 {
-    "output": {
+    "example_out": {
         "checksum": "sha1$47a013e660d408619d894b20806b1d5086aab03b",
         "basename": "output.txt",
         "nameroot": "output",

--- a/_includes/cwl/05-stdout/stdout.cwl
+++ b/_includes/cwl/05-stdout/stdout.cwl
@@ -10,5 +10,5 @@ inputs:
     inputBinding:
       position: 1
 outputs:
-  output:
+  example_out:
     type: stdout

--- a/_includes/cwl/conformance-test.yml
+++ b/_includes/cwl/conformance-test.yml
@@ -29,7 +29,7 @@
   job: 05-stdout/echo-job.yml
   tool: 05-stdout/stdout.cwl
   output:
-    output:
+    example_out:
       class: File
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
       basename: output.txt


### PR DESCRIPTION
It just replaces the output identifier with `example_out` to clarify it is user defined identifier.
