### PR TITLE
Update 04-output.md

### DIFF
--- a/_episodes/04-output.md
+++ b/_episodes/04-output.md
@@ -23,6 +23,15 @@ its results in the form of files created in the output directory.  The
 output parameters returned by the CWL tool are either the output files
 themselves, or come from examining the content of those files.
 
+The following example demonstrates how to return a file that has been extracted from a tar file.
+
+> ## Passing mandatory arguments to the `baseCommand`
+>
+> In previous examples, the `baseCommand` was just a string with any arguments passed as inputs.
+> Instead of a string array of strings can be used.  The first element is the command to run, and
+> any subsequent elements are mandatory command line arguments
+{: .callout}
+
 *tar.cwl*
 
 ~~~

--- a/_episodes/04-output.md
+++ b/_episodes/04-output.md
@@ -27,8 +27,8 @@ The following example demonstrates how to return a file that has been extracted 
 
 > ## Passing mandatory arguments to the `baseCommand`
 >
-> In previous examples, the `baseCommand` was just a string with any arguments passed as inputs.
-> Instead of a string array of strings can be used.  The first element is the command to run, and
+> In previous examples, the `baseCommand` was just a string, with any arguments passed as CWL inputs.
+> Instead of a single string we can use an _array of strings_.  The first element is the command to run, and
 > any subsequent elements are mandatory command line arguments
 {: .callout}
 


### PR DESCRIPTION
Added line detailing what the example shows, just in-case users are not familiar and a callout box explaining that baseCommand can take an array as well as a string.

