### PR TITLE
edit example_output values

### DIFF
--- a/_episodes/04-output.md
+++ b/_episodes/04-output.md
@@ -58,14 +58,12 @@ $ cwl-runner tar.cwl tar-job.yml
 [job tar.cwl] completed success
 {
     "example_out": {
-        "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
-        "basename": "hello.txt",
-        "nameroot": "hello",
-        "nameext": ".txt",
         "location": "file:///home/me/cwl/user_guide/hello.txt",
-        "path": "/home/me/cwl/user_guide/hello.txt",
+        "basename": "hello.txt",
         "class": "File",
-        "size": 0
+        "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "size": 0,
+        "path": "/home/me/cwl/user_guide/hello.txt"
     }
 }
 Final process status is success

--- a/_episodes/05-stdout.md
+++ b/_episodes/05-stdout.md
@@ -38,14 +38,12 @@ $ cwl-runner stdout.cwl echo-job.yml
 [job stdout.cwl] completed success
 {
     "example_out": {
-        "checksum": "sha1$47a013e660d408619d894b20806b1d5086aab03b",
-        "basename": "output.txt",
-        "nameroot": "output",
-        "nameext": ".txt",
         "location": "file:///home/me/cwl/user_guide/output.txt",
-        "path": "/home/me/cwl/user_guide/output.txt",
+        "basename": "output.txt",
         "class": "File",
-        "size": 13
+        "checksum": "sha1$47a013e660d408619d894b20806b1d5086aab03b",
+        "size": 13,
+        "path": "/home/me/cwl/user_guide/output.txt"
     }
 }
 Final process status is success

--- a/_episodes/06-params.md
+++ b/_episodes/06-params.md
@@ -43,14 +43,12 @@ $ cwl-runner tar-param.cwl tar-param-job.yml
 [job tar-param.cwl] completed success
 {
     "extracted_file": {
-        "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
-        "basename": "goodbye.txt",
-        "nameroot": "goodbye",
-        "nameext": ".txt",
         "location": "file:///home/me/cwl/user_guide/goodbye.txt",
-        "path": "/home/me/cwl/user_guide/goodbye.txt",
+        "basename": "goodbye.txt",
         "class": "File",
-        "size": 0
+        "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "size": 0,
+        "path": "/home/me/cwl/user_guide/goodbye.txt"
     }
 }
 Final process status is success


### PR DESCRIPTION
This change modifies the handling of the `"output"` in User Guide episode.
When using cwl-runner 1.0.20190621234233 , `"output"` should look like this change.


Additional Information : In my environment(MacOS 10.13.6), tmp directory was created different location. 
~~~
INFO [job stdout.cwl] /private/tmp/docker_tmpm6s0q0i0$ echo \
    'Hello world!' > /private/tmp/docker_tmpm6s0q0i0/output.txt
~~~