### PR TITLE
Update introductory text on landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,15 +9,15 @@ Hello!
 
 {% comment %} This is a comment in Liquid {% endcomment %}
 
-This guide will introduce you to writing tool wrappers and workflows using the Common Workflow Language (CWL). This guide describes the current stable specification, version 1.0.
+This guide will introduce you to writing tool wrappers and workflows using the Common Workflow Language (CWL). This guide describes the stable specification, version 1.0. Updates to the guide for more recent versions are ongoing.
 
 Note: This document is a work in progress. Not all features are covered, yet.
 
 > ## Prerequisites
 >
-> A text editor
+> * A text editor
 >
-> A CWL runner. It is recommended to start with the [reference implementation][cwltool-install]. The full list of CWL runners is on [the project homepage][cwl-runners-list].
+> * A CWL runner. It is recommended to start with the [reference implementation][cwltool-install]. The full list of CWL runners is on [the project homepage][cwl-runners-list].
 {: .prereq}
 
 [cwl-runners-list]: https://www.commonwl.org/#Implementations


### PR DESCRIPTION
This removes the adjective "current" when referring to version 1.0 and adds bullet points to the lines in the Prerequisites callout.