### PR TITLE
fix typo

### DIFF
--- a/_episodes/04-output.md
+++ b/_episodes/04-output.md
@@ -71,7 +71,7 @@ Final process status is success
 ~~~
 {: .output}
 
-The field `outputBinding` describes how to to set the value of each
+The field `outputBinding` describes how to set the value of each
 output parameter.
 
 ~~~


### PR DESCRIPTION
Removed extra "to" from the user guide.

Affected page: http://www.commonwl.org/user_guide/04-output/index.html

![Screenshot (25)_LI](https://user-images.githubusercontent.com/55043173/112799395-e8788b00-908b-11eb-9f68-679f86d3f303.jpg)
