### PR TITLE
Migrate schema from version http and 9.0 to https and latest

### DIFF
--- a/_includes/cwl/17-metadata/metadata_example3.cwl
+++ b/_includes/cwl/17-metadata/metadata_example3.cwl
@@ -52,5 +52,5 @@ $namespaces:
  edam: http://edamontology.org/
 
 $schemas:
- - http://schema.org/version/9.0/schemaorg-current-http.rdf
+ - https://schema.org/version/latest/schemaorg-current-http.rdf
  - http://edamontology.org/EDAM_1.18.owl

--- a/_includes/cwl/19-custom-types/custom-types.cwl
+++ b/_includes/cwl/19-custom-types/custom-types.cwl
@@ -58,7 +58,7 @@ $namespaces:
 
 $schemas:
   - http://edamontology.org/EDAM_1.16.owl
-  - http://schema.org/version/9.0/schemaorg-current-http.rdf
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
 
 s:license: https://spdx.org/licenses/Apache-2.0
 s:copyrightHolder: "EMBL - European Bioinformatics Institute"

--- a/_includes/cwl/20-software-requirements/custom-types.cwl
+++ b/_includes/cwl/20-software-requirements/custom-types.cwl
@@ -61,7 +61,7 @@ $namespaces:
  iana: https://www.iana.org/assignments/media-types/
  s: https://schema.org/
 $schemas:
- - http://schema.org/version/9.0/schemaorg-current-http.rdf
+ - https://schema.org/version/latest/schemaorg-current-http.rdf
 
 s:license: https://spdx.org/licenses/Apache-2.0
 s:copyrightHolder: "EMBL - European Bioinformatics Institute"


### PR DESCRIPTION
Version 9.0 no longer exists and creates the following error:  

```
Could not load extension schema http://schema.org/version/9.0/schemaorg-current-http.rdf: Error fetching http://schema.org/version/9.0/schemaorg-current-http.rdf: 404 Client Error: Not Found for url: https://schema.org/version/9.0/sche
maorg-current-http.rdf
```