### PR TITLE
Remove orphan tag from operations page

### DIFF
--- a/src/topics/operations.md
+++ b/src/topics/operations.md
@@ -1,7 +1,3 @@
----
-orphan: true
----
-
 # Operations
 
 Operation is a type of CWL process just like a workflow, a command line tool, or


### PR DESCRIPTION
Already included in the table of contents:

<https://www.commonwl.org/user_guide/topics/operations.html>

I think we can also close the old issue for operations? We have an initial page (above) that can now be improved.

Closes #218 