### PR TITLE
Document more features of cwltool

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install apt packages
         run: |
-          sudo apt-get install -y graphviz
+          sudo apt-get install -y graphviz tree
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _site
 .Rhistory
 .RData
 _build/
+build/
 *.egg-info/
 
 src/_includes/cwl/**/output.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,7 @@ build:
     nodejs: "16"
   apt_packages:
     - graphviz
+    - tree
 
 sphinx:
   configuration: src/conf.py

--- a/src/_includes/cwl/troubleshooting/troubleshooting-wf1-stepb-fixed.cwl
+++ b/src/_includes/cwl/troubleshooting/troubleshooting-wf1-stepb-fixed.cwl
@@ -1,0 +1,30 @@
+cwlVersion: v1.2
+class: Workflow
+
+inputs: []
+outputs: []
+
+steps:
+  step_a:
+    run:
+      class: CommandLineTool
+      inputs: []
+      outputs:
+        step_a_file:
+          type: File
+          outputBinding:
+            glob: 'step_a.txt'
+      arguments: ['touch', 'step_a.txt']
+    in: []
+    out: [step_a_file]
+  step_b:
+    run:
+      class: CommandLineTool
+      inputs: []
+      outputs: []
+      arguments: ['touch', 'step_b.txt']
+    # To force step_b to wait for step_a
+    in:
+      step_a_file:
+        source: step_a/step_a_file
+    out: []

--- a/src/_includes/cwl/troubleshooting/troubleshooting-wf1-stepb-fixed.cwl
+++ b/src/_includes/cwl/troubleshooting/troubleshooting-wf1-stepb-fixed.cwl
@@ -1,30 +1,46 @@
 cwlVersion: v1.2
 class: Workflow
 
-inputs: []
-outputs: []
+inputs:
+  text:
+    type: string
+    default: 'Hello World'
+outputs:
+  reversed_message:
+    type: string
+    outputSource: step_b/reversed_message
 
 steps:
   step_a:
     run:
       class: CommandLineTool
-      inputs: []
+      stdout: stdout.txt
+      inputs:
+        text: string
       outputs:
-        step_a_file:
+        step_a_stdout:
           type: File
           outputBinding:
-            glob: 'step_a.txt'
-      arguments: ['touch', 'step_a.txt']
-    in: []
-    out: [step_a_file]
+            glob: 'stdout.txt'
+      arguments: ['echo', '-n', '$(inputs.text)']
+    in:
+      text: text
+    out: [step_a_stdout]
   step_b:
     run:
       class: CommandLineTool
-      inputs: []
-      outputs: []
-      arguments: ['touch', 'step_b.txt']
-    # To force step_b to wait for step_a
+      stdout: stdout.txt
+      inputs:
+        step_a_stdout: File
+      outputs:
+        reversed_message:
+          type: string
+          outputBinding:
+            glob: stdout.txt
+            loadContents: true
+            outputEval: $(self[0].contents)
+      arguments: ['rev', '$(inputs.step_a_stdout)']
     in:
-      step_a_file:
-        source: step_a/step_a_file
-    out: []
+      step_a_stdout:
+        source: step_a/step_a_stdout
+    out: [reversed_message]

--- a/src/_includes/cwl/troubleshooting/troubleshooting-wf1-stepb-fixed.cwl
+++ b/src/_includes/cwl/troubleshooting/troubleshooting-wf1-stepb-fixed.cwl
@@ -22,7 +22,8 @@ steps:
           type: File
           outputBinding:
             glob: 'stdout.txt'
-      arguments: ['echo', '-n', '$(inputs.text)']
+      baseCommand: echo
+      arguments: [ '-n', '$(inputs.text)' ]
     in:
       text: text
     out: [step_a_stdout]

--- a/src/_includes/cwl/troubleshooting/troubleshooting-wf1-stepb-fixed.cwl
+++ b/src/_includes/cwl/troubleshooting/troubleshooting-wf1-stepb-fixed.cwl
@@ -40,7 +40,8 @@ steps:
             glob: stdout.txt
             loadContents: true
             outputEval: $(self[0].contents)
-      arguments: ['rev', '$(inputs.step_a_stdout)']
+      baseCommand: rev
+      arguments: [ $(inputs.step_a_stdout) ]
     in:
       step_a_stdout:
         source: step_a/step_a_stdout

--- a/src/_includes/cwl/troubleshooting/troubleshooting-wf1.cwl
+++ b/src/_includes/cwl/troubleshooting/troubleshooting-wf1.cwl
@@ -1,30 +1,46 @@
 cwlVersion: v1.2
 class: Workflow
 
-inputs: []
-outputs: []
+inputs:
+  text:
+    type: string
+    default: 'Hello World'
+outputs:
+  reversed_message:
+    type: string
+    outputSource: step_b/reversed_message
 
 steps:
   step_a:
     run:
       class: CommandLineTool
-      inputs: []
+      stdout: stdout.txt
+      inputs:
+        text: string
       outputs:
-        step_a_file:
+        step_a_stdout:
           type: File
           outputBinding:
-            glob: 'step_a.txt'
-      arguments: ['touch', 'step_a.txt']
-    in: []
-    out: [step_a_file]
+            glob: 'stdout.txt'
+      arguments: ['echo', '-n', '$(inputs.text)']
+    in:
+      text: text
+    out: [step_a_stdout]
   step_b:
     run:
       class: CommandLineTool
-      inputs: []
-      outputs: []
-      arguments: ['ouch', 'step_b.txt']
-    # To force step_b to wait for step_a
+      stdout: stdout.txt
+      inputs:
+        step_a_stdout: File
+      outputs:
+        reversed_message:
+          type: string
+          outputBinding:
+            glob: stdout.txt
+            loadContents: true
+            outputEval: $(self[0].contents)
+      arguments: ['revv', '$(inputs.step_a_stdout)']
     in:
-      step_a_file:
-        source: step_a/step_a_file
-    out: []
+      step_a_stdout:
+        source: step_a/step_a_stdout
+    out: [reversed_message]

--- a/src/_includes/cwl/troubleshooting/troubleshooting-wf1.cwl
+++ b/src/_includes/cwl/troubleshooting/troubleshooting-wf1.cwl
@@ -1,0 +1,30 @@
+cwlVersion: v1.2
+class: Workflow
+
+inputs: []
+outputs: []
+
+steps:
+  step_a:
+    run:
+      class: CommandLineTool
+      inputs: []
+      outputs:
+        step_a_file:
+          type: File
+          outputBinding:
+            glob: 'step_a.txt'
+      arguments: ['touch', 'step_a.txt']
+    in: []
+    out: [step_a_file]
+  step_b:
+    run:
+      class: CommandLineTool
+      inputs: []
+      outputs: []
+      arguments: ['ouch', 'step_b.txt']
+    # To force step_b to wait for step_a
+    in:
+      step_a_file:
+        source: step_a/step_a_file
+    out: []

--- a/src/_includes/cwl/troubleshooting/troubleshooting-wf1.cwl
+++ b/src/_includes/cwl/troubleshooting/troubleshooting-wf1.cwl
@@ -39,7 +39,8 @@ steps:
             glob: stdout.txt
             loadContents: true
             outputEval: $(self[0].contents)
-      arguments: ['revv', '$(inputs.step_a_stdout)']
+      baseCommand: revv
+      arguments: [ $(inputs.step_a_stdout) ]
     in:
       step_a_stdout:
         source: step_a/step_a_stdout

--- a/src/topics/index.md
+++ b/src/topics/index.md
@@ -21,4 +21,5 @@ best-practices.md
 file-formats.md
 metadata-and-authorship.md
 specifying-software-requirements.md
+troubleshooting.md
 ```

--- a/src/topics/inputs.md
+++ b/src/topics/inputs.md
@@ -33,16 +33,8 @@ Create a file called `inp-job.yml`:
 You can use `cwltool` to create a template input object. That saves you from having
 to type all the input parameters in a input object file:
 
-```bash
-$ cwltool --make-template inp.cwl
-INFO /home/kinow/Development/python/workspace/cwltool/venv/bin/cwltool 3.1.20220621073108
-INFO Resolved 'inp.cwl' to 'file:///tmp/inp.cwl'
-example_string: a_string  # type "string"
-example_int: 0  # type "int"
-example_flag: false  # type "boolean"
-example_file:  # type "File" (optional)
-    class: File
-    path: a/file/path
+```{runcmd} cwltool --make-template inp.cwl
+:working-directory: src/_includes/cwl/inputs
 ```
 
 You can redirect the output to a file, i.e. `cwltool --make-template inp.cwl > inp-job.yml`,

--- a/src/topics/inputs.md
+++ b/src/topics/inputs.md
@@ -29,6 +29,26 @@ Create a file called `inp-job.yml`:
 :name: inp-job.yml
 ```
 
+````{note}
+You can use `cwltool` to create a template input object. That saves you from having
+to type all the input parameters in a input object file:
+
+```bash
+$ cwltool --make-template inp.cwl
+INFO /home/kinow/Development/python/workspace/cwltool/venv/bin/cwltool 3.1.20220621073108
+INFO Resolved 'inp.cwl' to 'file:///tmp/inp.cwl'
+example_string: a_string  # type "string"
+example_int: 0  # type "int"
+example_flag: false  # type "boolean"
+example_file:  # type "File" (optional)
+    class: File
+    path: a/file/path
+```
+
+You can redirect the output to a file, i.e. `cwltool --make-template inp.cwl > inp-job.yml`,
+and then modify the default values with your desired input values.
+````
+
 Notice that "example_file", as a `File` type, must be provided as an
 object with the fields `class: File` and `path`.
 

--- a/src/topics/troubleshooting.md
+++ b/src/topics/troubleshooting.md
@@ -1,0 +1,151 @@
+# Troubleshooting
+
+In this section you will find ways to troubleshoot when you have problems executing CWL,
+specifically when using `cwltool` but some of these techniques may apply to different
+CWL Runners as well.
+
+## Run `cwltool` with `cachedir`
+
+You can use the `--cachedir` option when running a workflow to tell `cwltool` to
+cache intermediate files (files that are not input nor output files, but created
+during runtime for the execution). By default, these files are created in the
+temporary directory, but writing them to a separate directory makes it easier.
+
+The following example `troubleshooting-wf1.cwl` has a **typo in the second step**,
+where instead of calling `touch` is it calling `ouch`. We enforce the execution
+of `step_a`, followed by `step_b`. This means that the `step_a.txt` is produced
+before the `step_b` fails to produce a file.
+
+```{code-block} cwl
+:name: "`troubleshooting-wf1.cwl`"
+:caption: "`troubleshooting-wf1.cwl`"
+cwlVersion: v1.2
+class: Workflow
+
+inputs: []
+outputs: []
+
+steps:
+  step_a:
+    run:
+      class: CommandLineTool
+      inputs: []
+      outputs:
+        step_a_file:
+          type: File
+          outputBinding:
+            glob: 'step_a.txt'
+      arguments: ['touch', 'step_a.txt']
+    in: []
+    out: [step_a_file]
+  step_b:
+    run:
+      class: CommandLineTool
+      inputs: []
+      outputs: []
+      arguments: ['ouch', 'step_b.txt']
+    # To force step_b to wait for step_a
+    in:
+      step_a_file:
+        source: step_a/step_a_file
+    out: []
+```
+
+```{note}
+The CWL Standard does not guarantee the execution order of Workflow Steps. They can
+be executed in any arbitrary order, or in paralell. So the in the `troubleshooting-wf1.cwl`
+CWL document we enforce the order by chaining the output of `step_a` into an input
+of `step_b`.
+```
+
+Let's execute this workflow with `/tmp/cachedir/` as the `--cachedir` value (`cwltool` create the
+directory for you if it does not already exist):
+
+```{code-block} console
+:emphasize-lines: 12-14, 19-21
+$ cwltool --cachedir /tmp/cachedir/ troubleshoot_wf1.cwl
+INFO /home/kinow/Development/python/workspace/user_guide/venv/bin/cwltool 3.1.20220830195442
+INFO Resolved 'troubleshoot_wf1.cwl' to 'file:///tmp/troubleshoot_wf1.cwl'
+WARNING Workflow checker warning:
+troubleshoot_wf1.cwl:28:7: 'step_a_file' is not an input parameter of ordereddict([('class',
+                           'CommandLineTool'), ('inputs', []), ('outputs', []), ('arguments',
+                           ['ouch', 'step_b.txt']), ('id',
+                           '_:af6cdc76-ead7-4438-94a2-f9f96b3d70c5')]), expected
+INFO [workflow ] start
+INFO [workflow ] starting step step_a
+INFO [step step_a] start
+INFO [job step_a] Output of job will be cached in /tmp/cachedir/5504f8afaebc04b48f07e6e5f2b5237b
+INFO [job step_a] /tmp/cachedir/5504f8afaebc04b48f07e6e5f2b5237b$ touch \
+    step_a.txt
+INFO [job step_a] completed success
+INFO [step step_a] completed success
+INFO [workflow ] starting step step_b
+INFO [step step_b] start
+INFO [job step_b] Output of job will be cached in /tmp/cachedir/feec39505ecca29dce1a210f75b12283
+INFO [job step_b] /tmp/cachedir/feec39505ecca29dce1a210f75b12283$ ouch \
+    step_b.txt
+ERROR 'ouch' not found: [Errno 2] No such file or directory: 'ouch'
+WARNING [job step_b] completed permanentFail
+WARNING [step step_b] completed permanentFail
+INFO [workflow ] completed permanentFail
+{}
+WARNING Final process status is permanentFail
+```
+
+The workflow is in the `permanentFail` status, but you can inspect the intermediate
+files created:
+
+```{code-block} console
+:emphasize-lines: 4
+$ tree /tmp/cachedir
+/tmp/cachedir
+├── 5504f8afaebc04b48f07e6e5f2b5237b
+│   └── step_a.txt
+├── 5504f8afaebc04b48f07e6e5f2b5237b.status
+├── abz3v9aq
+├── feec39505ecca29dce1a210f75b12283
+└── feec39505ecca29dce1a210f75b12283.status
+
+3 directories, 3 files
+```
+
+The `.status` files display the status of each step executed by the workflow. And
+the `step_a.txt` is visible in the output. Note that `cwltool` shows what where
+the workflow step outputs are being cached near “`Output of job will be cached (…)`”.
+
+The next time you execute the same command, `cwltool` will use the cached output
+of the workflow steps. Before doing so, fix the typo so `step_b` now runs `touch`.
+After fixing the typo, when you execute `cwltool` with the same arguments as the
+previous time, note that `cwltool` output will contain information about pre-cached
+outputs, and about a new cache entry for the output of `step_b`.
+
+```{code-block} console
+:emphasize-lines: 12, 16-18
+$ cwltool --cachedir /tmp/cachedir/ troubleshoot_wf1.cwl
+INFO /home/kinow/Development/python/workspace/user_guide/venv/bin/cwltool 3.1.20220830195442
+INFO Resolved 'troubleshoot_wf1.cwl' to 'file:///tmp/troubleshoot_wf1.cwl'
+WARNING Workflow checker warning:
+troubleshoot_wf1.cwl:28:7: 'step_a_file' is not an input parameter of ordereddict([('class',
+                           'CommandLineTool'), ('inputs', []), ('outputs', []), ('arguments',
+                           ['touch', 'step_b.txt']), ('id',
+                           '_:50e379f8-dce8-4794-9142-c53dc4e0e30d')]), expected
+INFO [workflow ] start
+INFO [workflow ] starting step step_a
+INFO [step step_a] start
+INFO [job step_a] Using cached output in /tmp/cachedir/5504f8afaebc04b48f07e6e5f2b5237b
+INFO [step step_a] completed success
+INFO [workflow ] starting step step_b
+INFO [step step_b] start
+INFO [job step_b] Output of job will be cached in /tmp/cachedir/822d8caf8894683f434ed8eb8be1b10d
+INFO [job step_b] /tmp/cachedir/822d8caf8894683f434ed8eb8be1b10d$ touch \
+    step_b.txt
+INFO [job step_b] completed success
+INFO [step step_b] completed success
+INFO [workflow ] completed success
+{}
+INFO Final process status is success
+```
+
+In this example, the workflow step `step_a` was executed only once as its output was cached,
+even though we executed `cwltool` twice. This can be useful for troubleshooting your CWL document,
+while also avoiding recomputing steps.

--- a/src/topics/troubleshooting.md
+++ b/src/topics/troubleshooting.md
@@ -12,23 +12,16 @@ temporary directory but writing them to a separate directory makes accessing
 them easier.
 
 In the following example `troubleshooting-wf1.cwl` we have two steps, `step_a` and `step_b`.
-These two steps are executed in order (we enforce it, see note below). The first step,
-`step_a`, executes the `touch` command. The second step, `step_b`, **has a typo**,
-where instead of also executing the `touch` command it tries to execute `ouch`, which
+The workflow is equivalent to `echo "Hello World" | rev`, which would print the message
+"Hello World" reversed, i.e. "dlroW olleH". However, the second step, `step_b`, **has a typo**,
+where instead of executing the `rev` command it tries to execute `revv`, which
 fails.
 
 ```{literalinclude} /_includes/cwl/troubleshooting/troubleshooting-wf1.cwl
 :language: cwl
 :name: "`troubleshooting-wf1.cwl`"
 :caption: "`troubleshooting-wf1.cwl`"
-:emphasize-lines: 25
-```
-
-```{note}
-The CWL Standard does not guarantee the execution order of Workflow Steps. They can
-be executed in any arbitrary order, or in paralell. So the in the `troubleshooting-wf1.cwl`
-CWL document we enforce the order by chaining the output of `step_a` into an input
-of `step_b`.
+:emphasize-lines: 42
 ```
 
 Let's execute this workflow with `/tmp/cachedir/` as the `--cachedir` value (`cwltool` will
@@ -40,7 +33,7 @@ create the directory for you if it does not exist already):
 ```
 
 The workflow is in the `permanentFail` status due to `step_b` failing to execute the
-non-existent `ouch` command. The `step_a` was executed successfully and its output
+non-existent `revv` command. The `step_a` was executed successfully and its output
 has been cached in your `cachedir` location. You can inspect the intermediate files
 created:
 
@@ -50,9 +43,9 @@ created:
 
 Each workflow step has received a unique ID (the long value that looks like a hash).
 The `${HASH}.status` files display the status of each step executed by the workflow.
-And the `step_a` output file `step_a.txt` is visible in the output of the command above.
+And the `step_a` output file `stdout.txt` is visible in the output of the command above.
 
-Now fix the typo so `step_b` executes `touch` (i.e. replace `ouch` by `touch` in the
+Now fix the typo so `step_b` executes `rev` (i.e. replace `revv` by `rev` in the
 `step_b`). After fixing the typo, when you execute `cwltool` with the same arguments
 as the previous time, note that now `cwltool` output contains information about
 pre-cached outputs for `step_a`, and about a new cache entry for the output of `step_b`.
@@ -65,6 +58,6 @@ Also note that the status of `step_b` is now of success.
 
 In this example the workflow step `step_a` was not re-evaluated as it had been cached, and
 there was no change in its execution or output. Furthermore, `cwltool` was able to recognize
-when it had to re-evaluate `step_b` after we fixed its executable name. This technique is
+when it had to re-evaluate `step_b` after we fixed the executable name. This technique is
 useful for troubleshooting your CWL documents and also as a way to prevent `cwltool` to
 re-evaluate steps unnecessarily.


### PR DESCRIPTION
Partially addresses #166 

- [x] cwltool --make-template
- [x] cwltool --cachedir

For `--make-template`, I added a small paragraph to the Inputs section.

For `--cachedir`, I couldn't decide among prerequisites, FAQ, and a new section. In the end due to its length, I thought it would fit better in a new section for Troubleshooting (I imagine other devs have other interesting ways to troubleshoot CWL & cwltool execution). But happy to move it to somewhere else too.