### PR TITLE
fix: "Introduction" and "Core Concepts" embedded links

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -15,9 +15,9 @@ each page.
 
 ## Navigating the User Guide
 
-If you are a beginner user get started with the [Introduction](/introduction/index.md)
+If you are a beginner user get started with the [Introduction](/src/introduction/index.md)
 section. For advanced users the subsections of the
-[Core Concepts](/topics/index.md) have detailed information about the
+[Core Concepts](/src/topics/index.md) have detailed information about the
 most common topics for CWL.
 
 The Table of Contents is displayed at the top menu and also on the left sidebar.


### PR DESCRIPTION
Linked "Introduction" and "Core Concepts" to the right pages