### PR TITLE
Adjust install instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ in `Makefile`).
 python -m venv venv
 source venv/bin/activate
 # Install the dependencies in your virtual environment
-(venv) pip install -e .[all]
+(venv) python -mpip install .[all]
 # Create the HTML to visualize locally
 (venv) make html
 (venv) firefox _build/index.html


### PR DESCRIPTION
"pip install -e .[all]" doesn't work if you don't have setup.py. We're using a declarative package config so we need to invoke it as "python -mpip install .[all]".