### PR TITLE
Expand toc nav depth

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -187,7 +187,7 @@ html_theme_options = {
     ],
     "show_nav_level": 2,
     "navigation_depth": 2,
-    "collapse_navigation": False,
+    "collapse_navigation": True,
     "show_prev_next": True,
     "favicons": [
         {

--- a/src/conf.py
+++ b/src/conf.py
@@ -187,7 +187,7 @@ html_theme_options = {
     ],
     "show_nav_level": 2,
     "navigation_depth": 2,
-    "collapse_navigation": True,
+    "collapse_navigation": False,
     "show_prev_next": True,
     "favicons": [
         {

--- a/src/index.md
+++ b/src/index.md
@@ -28,7 +28,7 @@ the left sidebar.
 ## Table of Contents
 
 ```{toctree}
-:maxdepth: 2
+:maxdepth: 3
 :numbered:
 
 introduction/index.md


### PR DESCRIPTION
Increases the depth of the table of contents on the [home page](https://www.commonwl.org/user_guide/index.html) as mentioned in #252 
From: 
![current-toc](https://user-images.githubusercontent.com/51911758/195838367-26c6ed63-20ba-4604-99b8-e11b19026fcc.png)
To:
![expanded-toc](https://user-images.githubusercontent.com/51911758/195838390-03ad2dab-8994-471f-890c-9a0d4044c6ea.png)
