### PR TITLE
Add clarity for installing dependencies and pip command for Graphviz

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,10 +103,12 @@ python -m venv venv
 source venv/bin/activate
 # update the version of pip, setuptools, and wheel
 (venv) pip install -U pip setuptools wheel
-# Install the dependencies in your virtual environment
-(venv) pip install .[all]
+# Install all the dependencies in your virtual environment.
+# The dot or period at the end means that the dependencies are referenced is in the same directory as the current location).
+(venv) pip install .
 # Create the HTML to visualize locally
 (venv) make html
+(venv) pip install graphviz
 (venv) open _build/index.html
 # Or you can start a serve that watches for local file changes
 (venv) make watch


### PR DESCRIPTION
When I was setting up and going through the docs on CWL user_guide, I came noticed these and would like to suggest these changes.

- I added a comment and took out the [all] because I got a `zsh: no matches found: .[all]` and without the `all` it worked.

- Second thing I did was to add the pip install for the Graphviz. Initially, I got `dot command 'dot' cannot be run (needed for graphviz output), check the graphviz_dot setting` and I proceeded to install Graphviz which seemed to solve the problem. 
