### PR TITLE
User guide direct link

### DIFF
--- a/src/introduction/basic-concepts.md
+++ b/src/introduction/basic-concepts.md
@@ -179,6 +179,7 @@ vendors.
 
 - Semantic Versioning - <https://semver.org/>
 - The CWL Specification page in the CWL website: <https://www.commonwl.org/specification/>
+    - [See the Command Line Tool Description Standard](https://www.commonwl.org/v1.2/CommandLineTool.html)
 - The current CWL specification on GitHub: {{ '<https://github.com/common-workflow-language/cwl-{}>'.format(cwl_version_text) }}
 - The list of Implementations in the CWL website: <https://www.commonwl.org/implementations/>
 - PROV-O: The PROV Ontology - <https://www.w3.org/TR/prov-o/>


### PR DESCRIPTION
Alternative link that leads directly to Common Workflow Language Standards, v1.2 is added

Indicated by "see the command line Tool description standard"