### PR TITLE
add exclude_cache_cmd domain for CMDCache

### DIFF
--- a/cwl/sphinx/runcmd.py
+++ b/cwl/sphinx/runcmd.py
@@ -40,10 +40,13 @@ class Singleton(_Singleton("SingletonMeta", (object,), {})):
 
 class CMDCache(Singleton):
     cache = {}
+    exclude_cache_cmd = {hash("cat output.txt")}
 
     def get(self, cmd, working_directory):
         h = hash(cmd)
-        if h in self.cache:
+        if h in self.exclude_cache_cmd:
+            return run_command(cmd, working_directory)
+        elif h in self.cache:
             return self.cache[h]
         else:
             result = run_command(cmd, working_directory)


### PR DESCRIPTION
Usually, the results of `cat output.txt` are different in different working directory. But many results of this are `Message is: Hello world!`, such as [2.3 Expressions](https://common-workflow-languageuser-guide.readthedocs.io/en/latest/topics/expressions.html), [2.12. Environment Variables](https://common-workflow-languageuser-guide.readthedocs.io/en/latest/topics/environment-variables.html#), [2.13. Using Containers](https://common-workflow-languageuser-guide.readthedocs.io/en/latest/topics/using-containers.html), which are unexpected. Thus, I may consider to add a `exclude_cache_cmd` part to specify some cmd which results will not be cached.