### PR TITLE
Metadata and Authorship: Harmonize examples and highlight difference

### DIFF
--- a/src/_includes/cwl/metadata-and-authorship/metadata_example2.cwl
+++ b/src/_includes/cwl/metadata-and-authorship/metadata_example2.cwl
@@ -45,5 +45,5 @@ $namespaces:
   edam: http://edamontology.org/
 
 $schemas:
- - https://schema.org/version/latest/schemaorg-current-https.rdf
- - http://edamontology.org/EDAM_1.18.owl
+  - https://schema.org/version/latest/schemaorg-current-https.rdf
+  - http://edamontology.org/EDAM_1.18.owl

--- a/src/_includes/cwl/metadata-and-authorship/metadata_example3.cwl
+++ b/src/_includes/cwl/metadata-and-authorship/metadata_example3.cwl
@@ -48,9 +48,9 @@ s:keywords: edam:topic_0091 , edam:topic_0622
 s:programmingLanguage: C
 
 $namespaces:
- s: https://schema.org/
- edam: http://edamontology.org/
+  s: https://schema.org/
+  edam: http://edamontology.org/
 
 $schemas:
- - https://schema.org/version/latest/schemaorg-current-http.rdf
- - http://edamontology.org/EDAM_1.18.owl
+  - https://schema.org/version/latest/schemaorg-current-https.rdf
+  - http://edamontology.org/EDAM_1.18.owl

--- a/src/topics/metadata-and-authorship.md
+++ b/src/topics/metadata-and-authorship.md
@@ -36,6 +36,7 @@ requirements in order to use the tool, and a few more metadata fields.
 :language: cwl
 :caption: "`metadata_example3.cwl`"
 :name: metadata_example3.cwl
+:emphasize-lines: 8-10, 47-48
 ```
 
 [schema-salad]: https://www.commonwl.org/v1.0/SchemaSalad.html#Explicit_context


### PR DESCRIPTION
The examples in `metadata_example2.cwl` and `metadata_example3.cwl` are meant to be compared, and the latter is an extension of the former. However, the differences are not obvious in the wall of text.

For this, line-highlighting is used in the latter to point out the different parts.

In addition, minor/trivial differences in the pair are removed, so they differ *only* in the highlighted lines. This also fixes some minor, inconsistent indentations.