### PR TITLE
Minor edits to staging branch

### DIFF
--- a/src/faq.md
+++ b/src/faq.md
@@ -131,10 +131,6 @@ baseCommand: sh
 outputs: []
 ```
 
-```{note}
-In CWL, everything must be directly stated.
-```
-
 ## Setting `self`-based Input Bindings for Optional Inputs
 
 Currently, `cwltool` can't cope with missing optional inputs if their

--- a/src/introduction/basic-concepts.md
+++ b/src/introduction/basic-concepts.md
@@ -159,8 +159,8 @@ in detail in the [Requirements](../topics/requirements-and-hints.md) section.
 > machine accessibility and that all digital assets should be Findable,
 > Accessible, Interoperable, and Reusable. Workflows encode the methods
 > by which the scientific process is conducted and via which data are
-> created. It is thus important that workflows support the creation
-> of FAIR data and adhere to the FAIR principles.
+> created. It is thus important that workflows both support the creation
+> of FAIR data and themselves adhere to the FAIR principles.
 > — [FAIR Computational Workflows](https://workflows.community/groups/fair/),
 > Workflows Community Initiative.
 

--- a/src/topics/operations.md
+++ b/src/topics/operations.md
@@ -52,8 +52,8 @@ style=dashed;
 }
 ```
 
-If you try running it with `cwltool`, the command will fail since `cwltool`
-does not have enough information to know how to execute it:
+The operation file will fail to run with `cwltool` because `cwltool`
+lacks the necessary information to execute it:
 
 ```{runcmd} cwltool operations.cwl --message Hello
 :working-directory: src/_includes/cwl/operations/


### PR DESCRIPTION
As discussed here: https://github.com/common-workflow-language/user_guide/pull/373#issuecomment-1772100153

1. Basic Concepts - Roll back changes to quote fair principles verbatim

2. Operations - Reword the operation file sentence - this is contrary to the discussion on https://github.com/common-workflow-language/user_guide/pull/373#issuecomment-1772100153 and instead have reworded this entirely - please discuss otherwise can go back to the 'then' addition.

3. FAQ - remove vague comment 'everything in CWL must be stated'
 
   Code 'note' is removed from the FAQ.md file